### PR TITLE
90% Added get user profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ php:
   - 5.4
   - 5.3
 
+install:
+  - composer install
+  
 script: ant unittest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: php
+php:
+  - 5.5
+  - 5.4
+  - 5.3
+
+script: ant unittest

--- a/README.md
+++ b/README.md
@@ -62,3 +62,13 @@ STATSD_PREFIX=dev.myapp
 ```
 
 The prefix is optional, if not supplied all stats will be prefixed with `persona.php.client`
+
+## Testing
+### Unit tests
+```
+ant unittest
+```
+### Integration Tests
+```
+ant integrationtest
+```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ $tokenDetails = $personaClient->obtainNewToken("your client id", "your client se
 
 // you can use it to validate a token
 $personaClient->validateToken(array("access_token"=>"some token"));
+
+// you can use it to get a user profile with the gupid
+$profile = $personaClient->getUserByGupid("google:123", "some token");
 ```
 
 By default, obtainNewToken will deal with managing a cookie to cache to oauth token, the expiry will match that returned by Persona. If you are using this library in a cookie-less environment (e.g. background job) you can disable this behaviour:

--- a/src/personaclient/PersonaClient.php
+++ b/src/personaclient/PersonaClient.php
@@ -294,12 +294,43 @@ class PersonaClient {
         $url = $this->config['persona_host'].'/users/?gupid='.$gupid;
         $user = $this->personaGetUser($url, $token);
 
-        if($user && !empty($user))
+        if(isset($user) && !empty($user))
         {
             return $user;
         } else
         {
             throw new \Exception('User profile not found');
+        }
+    }
+
+    /**
+     * Get user profiles based off an array of guids
+     * @param array $guids
+     * @param string $token
+     * @access public
+     * @return array
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function getUserByGuids($guids, $token)
+    {
+        if(!is_array($guids))
+        {
+            throw new \InvalidArgumentException("Invalid guids");
+        }
+        if(trim($token) === '')
+        {
+            throw new \InvalidArgumentException("Invalid token");
+        }
+        $url = $this->config['persona_host'].'/users/?guids='.implode(',', $guids);
+        $users = $this->personaGetUser($url, $token);
+
+        if(isset($users) && !empty($users))
+        {
+            return $users;
+        } else
+        {
+            throw new \Exception('User profiles not found');
         }
     }
 
@@ -554,8 +585,7 @@ class PersonaClient {
 
         if (isset($headers['http_code']) && $headers['http_code'] === 200)
         {
-            $data = json_decode($response,true);
-            return $data;
+            return json_decode($response,true);
         } else
         {
             throw new \Exception("Could not retrieve OAuth response code");

--- a/test/unit/PersonaClientTest.php
+++ b/test/unit/PersonaClientTest.php
@@ -363,4 +363,92 @@ class PersonaClientTest extends TestBase {
         $token = $mockClient->obtainNewToken('client_id','client_secret');
         $this->assertEquals($token['access_token'],"foo");
     }
+
+    function testGetUserByGupidEmptyGupidThrowsException(){
+        $this->setExpectedException('InvalidArgumentException', 'Invalid gupid');
+        $personaClient = new \personaclient\PersonaClient(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->getUserByGupid('', '');
+    }
+    function testGetUserByGupidEmptyTokenThrowsException(){
+        $this->setExpectedException('InvalidArgumentException', 'Invalid token');
+        $personaClient = new \personaclient\PersonaClient(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->getUserByGupid('123', '');
+    }
+    function testGetUserByGupidInvalidTokenThrowsException(){
+        $this->setExpectedException('Exception', 'Could not retrieve OAuth response code');
+        $personaClient = new \personaclient\PersonaClient(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->getUserByGupid('123', '456');
+    }
+    function testGetUserByGupidThrowsExceptionWhenGupidNotFound()
+    {
+        $this->setExpectedException('Exception', 'User profile not found');
+        $mockClient = $this->getMock('\personaclient\PersonaClient',array('personaGetUser'),array(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        )));
+        $mockClient->expects($this->once())
+            ->method('personaGetUser')
+            ->will($this->returnValue(false));
+
+        $mockClient->getUserByGupid('123', '456');
+    }
+    function testGetUserByGupidReturnsUserWhenGupidFound()
+    {
+        $mockClient = $this->getMock('\personaclient\PersonaClient',array('personaGetUser'),array(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        )));
+        $expectedResponse = array(
+            '_id' => '123',
+            'guid' => '456',
+            'gupids' => array('google:789'),
+            'created' => array(
+                'sec' => 1,
+                'u' => 2
+            ),
+            'profile' => array(
+                'email' => 'max@payne.com',
+                'name' => 'Max Payne'
+            )
+        );
+        $mockClient->expects($this->once())
+            ->method('personaGetUser')
+            ->will($this->returnValue($expectedResponse));
+
+        $user = $mockClient->getUserByGupid('123', '456');
+        $this->assertEquals('123', $user['_id']);
+        $this->assertEquals('456', $user['guid']);
+        $this->assertInternalType('array', $user['gupids']);
+        $this->assertCount(1, $user['gupids']);
+        $this->assertEquals('google:789', $user['gupids'][0]);
+        $this->assertInternalType('array', $user['created']);
+        $this->assertInternalType('array', $user['profile']);
+        $this->assertCount(2, $user['profile']);
+        $this->assertEquals('max@payne.com', $user['profile']['email']);
+        $this->assertEquals('Max Payne', $user['profile']['name']);
+    }
 }

--- a/test/unit/PersonaClientTest.php
+++ b/test/unit/PersonaClientTest.php
@@ -451,4 +451,93 @@ class PersonaClientTest extends TestBase {
         $this->assertEquals('max@payne.com', $user['profile']['email']);
         $this->assertEquals('Max Payne', $user['profile']['name']);
     }
+
+    function testGetUserByGuidsInvalidGuidsThrowsException(){
+        $this->setExpectedException('InvalidArgumentException', 'Invalid guids');
+        $personaClient = new \personaclient\PersonaClient(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->getUserByGuids('', '');
+    }
+    function testGetUserByGuidsEmptyTokenThrowsException(){
+        $this->setExpectedException('InvalidArgumentException', 'Invalid token');
+        $personaClient = new \personaclient\PersonaClient(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->getUserByGuids(array('123'), '');
+    }
+    function testGetUserByGuidsInvalidTokenThrowsException(){
+        $this->setExpectedException('Exception', 'Could not retrieve OAuth response code');
+        $personaClient = new \personaclient\PersonaClient(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->getUserByGuids(array('123'), '456');
+    }
+    function testGetUserByGuidsThrowsExceptionWhenGuidsNotFound()
+    {
+        $this->setExpectedException('Exception', 'User profiles not found');
+        $mockClient = $this->getMock('\personaclient\PersonaClient',array('personaGetUser'),array(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        )));
+        $mockClient->expects($this->once())
+            ->method('personaGetUser')
+            ->will($this->returnValue(false));
+
+        $mockClient->getUserByGuids(array('HK-47'), '456');
+    }
+    function testGetUserByGuidsReturnsUserWhenGuidsFound()
+    {
+        $mockClient = $this->getMock('\personaclient\PersonaClient',array('personaGetUser'),array(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        )));
+        $expectedResponse = array(array(
+            '_id' => '123',
+            'guid' => '456',
+            'gupids' => array('google:789'),
+            'created' => array(
+                'sec' => 1,
+                'u' => 2
+            ),
+            'profile' => array(
+                'email' => 'max@payne.com',
+                'name' => 'Max Payne'
+            )
+        ));
+        $mockClient->expects($this->once())
+            ->method('personaGetUser')
+            ->will($this->returnValue($expectedResponse));
+
+        $users = $mockClient->getUserByGuids(array('123'), '456');
+        $this->assertCount(1, $users);
+        $this->assertEquals('123', $users[0]['_id']);
+        $this->assertEquals('456', $users[0]['guid']);
+        $this->assertInternalType('array', $users[0]['gupids']);
+        $this->assertCount(1, $users[0]['gupids']);
+        $this->assertEquals('google:789', $users[0]['gupids'][0]);
+        $this->assertInternalType('array', $users[0]['created']);
+        $this->assertInternalType('array', $users[0]['profile']);
+        $this->assertCount(2, $users[0]['profile']);
+        $this->assertEquals('max@payne.com', $users[0]['profile']['email']);
+        $this->assertEquals('Max Payne', $users[0]['profile']['name']);
+    }
 }


### PR DESCRIPTION
This introduces new methods: ```getUserByGupid``` (which expects a gupid and token as params), ```getUserByGuids``` (expects array of guids and a token) and makes a call to Persona for user profile(s). 

Calls to Persona using a gupid is done in a different way to when you use a guid, so i've kept the calls separate.

Also
* Added Travis CI file
* Updated docblocks and README so they were valid
* Added missing ```curl_close``` on some existing curl calls.
