### PR TITLE
90% Added code to patch a users corresponding oauth client

### DIFF
--- a/src/Talis/Persona/Client/OAuthClients.php
+++ b/src/Talis/Persona/Client/OAuthClients.php
@@ -38,7 +38,7 @@ class OAuthClients extends Base
      * @param string $clientId
      * @param array $properties
      * @param string $token
-     * @return mixed
+     * @return boolean
      * @access public
      * @throws \InvalidArgumentException
      * @throws \Exception
@@ -123,7 +123,7 @@ class OAuthClients extends Base
      * Get an OAuth Client
      * @param string $url
      * @param string $token
-     * @return array
+     * @return boolean
      * @throws \Exception
      */
     protected function personaGetOAuthClient($url, $token)
@@ -145,7 +145,7 @@ class OAuthClients extends Base
 
         if (isset($headers['http_code']) && $headers['http_code'] === 200)
         {
-            return json_decode($response,true);
+            return true;
         } else
         {
             throw new \Exception("Could not retrieve OAuth response code");

--- a/src/Talis/Persona/Client/OAuthClients.php
+++ b/src/Talis/Persona/Client/OAuthClients.php
@@ -1,0 +1,154 @@
+<?php
+namespace Talis\Persona\Client;
+
+class OAuthClients extends Base
+{
+    /**
+     * Return an outh client
+     * @param string $clientId
+     * @param string $token
+     * @return array
+     * @throws \Exception
+     */
+    public function getOAuthClient($clientId, $token)
+    {
+        if(!is_string($clientId) || trim($clientId) === '')
+        {
+            throw new \InvalidArgumentException("Invalid clientId");
+        }
+        if(!is_string($token) || trim($token) === '')
+        {
+            throw new \InvalidArgumentException("Invalid token");
+        }
+
+        $url = $this->config['persona_host'].'/clients/'.$clientId;
+
+        try
+        {
+            $client = $this->personaGetOAuthClient($url, $token);
+            return $client;
+        } catch(\Exception $e)
+        {
+            throw new \Exception('OAuth client not found');
+        }
+    }
+
+    /**
+     * Update a users OAuth client
+     * @param string $clientId
+     * @param array $properties
+     * @param string $token
+     * @return mixed
+     * @access public
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function updateOAuthClient($clientId, $properties, $token)
+    {
+        if(!is_string($clientId) || trim($clientId) === '')
+        {
+            throw new \InvalidArgumentException('Invalid guid');
+        }
+        if(!is_array($properties) || empty($properties))
+        {
+            throw new \InvalidArgumentException('Invalid properties');
+        }
+
+        // Check valid keys.
+        // "scope" only supports 2 keys, "$add" and "$remove". These 2 checks
+        // ensure that at least 1 of these must be present, and that there are no others passed through.
+        if(!isset($properties['scope']) || count($properties['scope']) == 0)
+        {
+            throw new \InvalidArgumentException('Invalid properties');
+        } else if(count(array_intersect(array('$add', '$remove'), array_keys($properties['scope']))) !== count($properties['scope']))
+        {
+            throw new \InvalidArgumentException('Invalid properties');
+        }
+
+        if(!is_string($token) || trim($token) === '')
+        {
+            throw new \InvalidArgumentException('Invalid token');
+        }
+
+        $url = $this->config['persona_host'].'/clients/'.$clientId;
+
+        try
+        {
+            $client = $this->personaPatchOAuthClient($url, $properties, $token);
+            return $client;
+        } catch(\Exception $e)
+        {
+            throw new \Exception('OAuth client not updated');
+        }
+    }
+
+    /**
+     * Patch an OAuth Client
+     * @param string $url
+     * @param array $properties
+     * @param string $token
+     * @return mixed
+     * @access protected
+     * @throws \Exception
+     */
+    protected function personaPatchOAuthClient($url, $properties, $token)
+    {
+        $curlOptions = array(
+            CURLOPT_CUSTOMREQUEST   => 'PATCH',
+            CURLOPT_URL             => $url,
+            CURLOPT_FOLLOWLOCATION  => true,
+            CURLOPT_RETURNTRANSFER  => true,
+            CURLOPT_TIMEOUT         => 30,
+            CURLOPT_POSTFIELDS      => json_encode($properties),
+            CURLOPT_HTTPHEADER      => array('Authorization: Bearer ' . $token)
+        );
+
+        $curl = curl_init();
+        curl_setopt_array($curl, $curlOptions);
+
+        $response = curl_exec($curl);
+        $headers = curl_getinfo($curl);
+        curl_close($curl);
+
+        if (isset($headers['http_code']) && $headers['http_code'] === 204)
+        {
+            return json_decode($response,true);
+        } else
+        {
+            throw new \Exception("Could not retrieve OAuth response code");
+        }
+    }
+
+    /**
+     * Get an OAuth Client
+     * @param string $url
+     * @param string $token
+     * @return array
+     * @throws \Exception
+     */
+    protected function personaGetOAuthClient($url, $token)
+    {
+        $curlOptions = array(
+            CURLOPT_URL             => $url,
+            CURLOPT_RETURNTRANSFER  => true,
+            CURLOPT_FOLLOWLOCATION  => true,
+            CURLOPT_TIMEOUT         => 30,
+            CURLOPT_HTTPHEADER      => array('Authorization: Bearer ' . $token)
+        );
+
+        $curl = curl_init();
+        curl_setopt_array($curl, $curlOptions);
+
+        $response = curl_exec($curl);
+        $headers = curl_getinfo($curl);
+        curl_close($curl);
+
+        if (isset($headers['http_code']) && $headers['http_code'] === 200)
+        {
+            return json_decode($response,true);
+        } else
+        {
+            throw new \Exception("Could not retrieve OAuth response code");
+        }
+    }
+}

--- a/test/unit/OAuthClientsTest.php
+++ b/test/unit/OAuthClientsTest.php
@@ -1,0 +1,296 @@
+<?php
+
+use Talis\Persona\Client\OAuthClients;
+
+$appRoot = dirname(dirname(__DIR__));
+if (!defined('APPROOT'))
+{
+    define('APPROOT', $appRoot);
+}
+
+require_once $appRoot . '/test/unit/TestBase.php';
+
+class OAuthClientsTest extends TestBase
+{
+    // Get oauth client tests
+    function testGetOAuthClientEmptyClientIdThrowsException(){
+        $this->setExpectedException('InvalidArgumentException', 'Invalid clientId');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->getOAuthClient('', '');
+    }
+    function testGetOAuthClientEmptyTokenThrowsException(){
+        $this->setExpectedException('InvalidArgumentException', 'Invalid token');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->getOAuthClient('123', '');
+    }
+    function testGetOAuthClientInvalidTokenThrowsException(){
+        $this->setExpectedException('Exception', 'OAuth client not found');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->getOAuthClient('123', '456');
+    }
+    function testGetOAuthClientThrowsExceptionWhenClientNotFound()
+    {
+        $this->setExpectedException('Exception', 'OAuth client not found');
+        $mockClient = $this->getMock('Talis\Persona\Client\OAuthClients',array('personaGetOAuthClient'),array(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        )));
+        $mockClient->expects($this->once())
+            ->method('personaGetOAuthClient')
+            ->will($this->throwException(new Exception('Could not retrieve OAuth response code')));
+
+        $mockClient->getOAuthClient('123', '456');
+    }
+    function testGetOAuthClientReturnsClientWhenGupidFound()
+    {
+        $mockClient = $this->getMock('Talis\Persona\Client\OAuthClients',array('personaGetOAuthClient'),array(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        )));
+        $expectedResponse = array(
+            'rate_limit' => 1000,
+            'rate_duration' => 1800,
+            'rate_expires' => 1433516934,
+            'call_count' => 0,
+            'scope' => array(
+                'su'
+            )
+        );
+        $mockClient->expects($this->once())
+            ->method('personaGetOAuthClient')
+            ->will($this->returnValue($expectedResponse));
+
+        $client = $mockClient->getOAuthClient('123', '456');
+        $this->assertEquals($expectedResponse['rate_limit'], $client['rate_limit']);
+        $this->assertEquals($expectedResponse['rate_duration'], $client['rate_duration']);
+        $this->assertEquals($expectedResponse['rate_expires'], $client['rate_expires']);
+        $this->assertEquals($expectedResponse['call_count'], $client['call_count']);
+        $this->assertEquals($expectedResponse['scope'], $client['scope']);
+    }
+
+    // update oauth client tests
+    function testUpdateOAuthClientNoGupid()
+    {
+        $this->setExpectedException('Exception', 'Missing argument 1');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient();
+    }
+    function testUpdateOAuthClientNoProperties()
+    {
+        $this->setExpectedException('Exception', 'Missing argument 2');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123');
+    }
+    function testUpdateOAuthClientNoToken()
+    {
+        $this->setExpectedException('Exception', 'Missing argument 3');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123', array());
+    }
+    function testUpdateOAuthClientEmptyGuid()
+    {
+        $this->setExpectedException('Exception', 'Invalid guid');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('', array(), '987');
+    }
+    function testUpdateOAuthClientInvalidGuid()
+    {
+        $this->setExpectedException('Exception', 'Invalid guid');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient(array(), array(), '987');
+    }
+    function testUpdateOAuthClientEmptyProperties()
+    {
+        $this->setExpectedException('Exception', 'Invalid properties');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123', array(), '987');
+    }
+    function testUpdateOAuthClientInvalidProperties()
+    {
+        $this->setExpectedException('Exception', 'Invalid properties');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123', 'PROPERTIES', '987');
+    }
+    function testUpdateOAuthClientInvalidPropertiesKeys()
+    {
+        $this->setExpectedException('Exception', 'Invalid properties');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123', array('INVALID' => array()), '987');
+    }
+    function testUpdateOAuthClientInvalidPropertiesScopeKeys1()
+    {
+        $this->setExpectedException('Exception', 'Invalid properties');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123', array('scope' => array()), '987');
+    }
+    function testUpdateOAuthClientInvalidPropertiesScopeKeys2()
+    {
+        $this->setExpectedException('Exception', 'Invalid properties');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123', array('scope' => array('blah' => '')), '987');
+    }
+    function testUpdateOAuthClientInvalidPropertiesScopeKeys3()
+    {
+        $this->setExpectedException('Exception', 'Invalid properties');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123', array('scope' => array('blah' => '', '$add' => 'test')), '987');
+    }
+    function testUpdateOAuthClientInvalidPropertiesScopeKeys4()
+    {
+        $this->setExpectedException('Exception', 'Invalid properties');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123', array('scope' => array('blah' => '', '$remove' => 'remove-scope', '$add' => 'add-scope')), '987');
+    }
+    function testUpdateOAuthClientsEmptyToken()
+    {
+        $this->setExpectedException('Exception', 'Invalid token');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123', array('scope' => array('$add' => 'additional-scope')), '');
+    }
+    function testUpdateOAuthClientsInvalidToken()
+    {
+        $this->setExpectedException('Exception', 'Invalid token');
+        $personaClient = new OAuthClients(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        ));
+        $personaClient->updateOAuthClient('123',  array('scope' => array('$add' => 'additional-scope')), array(''));
+    }
+    function testUpdateOAuthClientPutFails()
+    {
+        $this->setExpectedException('Exception', 'OAuth client not updated');
+        $mockClient = $this->getMock('Talis\Persona\Client\OAuthClients',array('personaPatchOAuthClient'),array(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        )));
+        $mockClient->expects($this->once())
+            ->method('personaPatchOAuthClient')
+            ->will($this->throwException(new Exception('Could not retrieve OAuth response code')));
+
+        $mockClient->updateOAuthClient('guid', array('scope' => array('$add' => 'additional-scope')), '123');
+    }
+    function testUpdateOAuthClientPutSucceeds()
+    {
+        $mockClient = $this->getMock('Talis\Persona\Client\OAuthClients',array('personaPatchOAuthClient'),array(array(
+            'persona_host' => 'localhost',
+            'persona_oauth_route' => '/oauth/tokens',
+            'tokencache_redis_host' => 'localhost',
+            'tokencache_redis_port' => 6379,
+            'tokencache_redis_db' => 2,
+        )));
+
+        $expectedResponse = array(); // 204 has no content
+        $mockClient->expects($this->once())
+            ->method('personaPatchOAuthClient')
+            ->will($this->returnValue($expectedResponse));
+        $this->assertEquals($expectedResponse, $mockClient->updateOAuthClient('123', array('scope' => array('$add' => 'additional-scope')), '123'));
+    }
+}


### PR DESCRIPTION
Allows the ability to patch a users oauth client. This is primarily so that you can add/remove scopes from a user.

#### Todo
* ~~Add stricter checking around what can/cannot be updated in `$properties`~~
* ~~~Unit tests~~~