### PR TITLE
90% - PLAT-140 - Missing variable

### DIFF
--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -290,16 +290,16 @@ abstract class Base
                 array("opts" => $opts, "url" => $url, "response" => $response)
             );
 
-            switch ($headers['http_code']) {
+            switch ($response->getStatusCode()) {
             case 404:
                 throw new NotFoundException(
                     "Received 404 response from persona",
-                    $headers['http_code']
+                    $response->getStatusCode()
                 );
             default:
                 throw new \Exception(
                     "Did not retrieve successful response code from persona",
-                    $headers['http_code']
+                    $response->getStatusCode()
                 );
             }
         }

--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -283,25 +283,16 @@ abstract class Base
             );
         }
 
-        // Unexpected result
         if ($response->getStatusCode() != $expectedResponseCode) {
             $this->getLogger()->error(
-                "Did not retrieve successful response code",
+                "Did not retrieve expecteded response code",
                 array("opts" => $opts, "url" => $url, "response" => $response)
             );
 
-            switch ($response->getStatusCode()) {
-            case 404:
-                throw new NotFoundException(
-                    "Received 404 response from persona",
-                    $response->getStatusCode()
-                );
-            default:
-                throw new \Exception(
-                    "Did not retrieve successful response code from persona",
-                    $response->getStatusCode()
-                );
-            }
+            throw new \Exception(
+                "Did not retrieve expected response code from persona",
+                $response->getStatusCode()
+            );
         }
 
         // Not expecting a body to be returned

--- a/test/unit/TokensTest.php
+++ b/test/unit/TokensTest.php
@@ -476,7 +476,6 @@ class TokensTest extends TestBase {
 
             $this->fail('Exception not thrown');
         } catch (\Exception $exception) {
-            var_dump($exception->getMessage());
             $this->assertEquals(202, $exception->getCode());
         }
     }

--- a/test/unit/TokensTest.php
+++ b/test/unit/TokensTest.php
@@ -433,7 +433,7 @@ class TokensTest extends TestBase {
     /**
      * HTTP endpoint returns odd status code
      */
-    public function testReturnOddStatusCode()
+    public function testReturnUnexpectedStatusCode()
     {
         $mockClient = $this->getMock(
             'Talis\Persona\Client\Tokens',

--- a/test/unit/TokensTest.php
+++ b/test/unit/TokensTest.php
@@ -431,7 +431,7 @@ class TokensTest extends TestBase {
     }
 
     /**
-     * HTTP endpoint returns odd status code
+     * HTTP endpoint returns unexpected status code
      */
     public function testReturnUnexpectedStatusCode()
     {

--- a/test/unit/TokensTest.php
+++ b/test/unit/TokensTest.php
@@ -2,6 +2,7 @@
 
 use \Firebase\JWT\JWT;
 use Talis\Persona\Client\Tokens;
+use Guzzle;
 
 $appRoot = dirname(dirname(__DIR__));
 if (!defined('APPROOT'))
@@ -426,6 +427,57 @@ class TokensTest extends TestBase {
 
             $this->fail("Exception not thrown");
         } catch (InvalidArgumentException $e) {
+        }
+    }
+
+    /**
+     * HTTP endpoint returns odd status code
+     */
+    public function testReturnOddStatusCode()
+    {
+        $mockClient = $this->getMock(
+            'Talis\Persona\Client\Tokens',
+            array('getHTTPClient'),
+            array(array(
+                'persona_host' => 'localhost',
+                'persona_oauth_route' => '/oauth/tokens',
+            ))
+        );
+
+        $plugin = new Guzzle\Plugin\Mock\MockPlugin();
+        $plugin->addResponse(new Guzzle\Http\Message\Response(202));
+        $httpClient = new Guzzle\Http\Client();
+        $httpClient->addSubscriber($plugin);
+
+        $jwt = JWT::encode(
+            array(
+                'jwtid' => time(),
+                'exp' => time() + 100,
+                'nbf' => time() - 1,
+                'audience' => 'standard_user',
+                'scopeCount' => 10,
+            ),
+            $this->_privateKey,
+            'RS256'
+        );
+
+        $mockClient
+            ->expects($this->once())
+            ->method('getHTTPClient')
+            ->will($this->returnValue($httpClient));
+
+        try {
+            $mockClient->validateToken(
+                array(
+                    'access_token' => $jwt,
+                    'scope' => 'su',
+                )
+            );
+
+            $this->fail('Exception not thrown');
+        } catch (\Exception $exception) {
+            var_dump($exception->getMessage());
+            $this->assertEquals(202, $exception->getCode());
         }
     }
 }


### PR DESCRIPTION
Uncommon route includes a missing variable. Bug would be triggered if the JWT token didn't include a list of scopes & the HTTP response from Persona didn't respond as the client expected it.

fixes https://github.com/talis/platform/issues/204