### PR TITLE
90% - PLAT-356 - Remove default cache backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ $personaClient = new Talis\Persona\Client\Login(array(
 ));
 ```
 
+** WARNING **
+The FileSystemCache caching mechanism has been found to generated 32 folders per cache
+key & does not clean down old cache keys. This causes the file system to deplete all
+available inodes. It is recommended to not use the FileSystemCache object.
+
 Where applicable, each API call can override the global TTL by passing in a TTL value.
 ```php
 $cacheTTL = 300;

--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ To use the module in your code, instantiate one of the following:
 * ```new Talis\Persona\Client\OAuthClients``` - for oauth based Persona calls
 
 ### Caching
-By default the cache storage mechanism is file based which uses the system's temporary directory.
 Every HTTP GET or HEAD request is cached for 500 seconds unless the TTL
-value is overridden. The storage mechanism can be changed by defining the
-cache driver. A list of cache driver implementations can be found
+value is overridden. The storage mechanism is defined the cache driver.
+A list of cache driver implementations can be found
 [here](https://github.com/doctrine/cache/tree/master/lib/Doctrine/Common/Cache).
 ```php
 $redis = new Redis();
@@ -53,7 +52,7 @@ $personaClient = new Talis\Persona\Client\Login(array(
 ));
 ```
 
-** WARNING **
+**WARNING**
 The FileSystemCache caching mechanism has been found to generated 32 folders per cache
 key & does not clean down old cache keys. This causes the file system to deplete all
 available inodes. It is recommended to not use the FileSystemCache object.
@@ -79,6 +78,7 @@ $personaClient = new Talis\Persona\Client\Tokens(array(
     'persona_host' => 'https://users.talis.com',
     'persona_oauth_route' => '/oauth/tokens',
     'userAgent' => 'my-app/2.0',
+    'cacheBackend' => $cacheBackend,
 ));
 
 // you can use it to obtain a new token
@@ -105,6 +105,7 @@ $personaClient = new Talis\Persona\Client\Users(array(
     'persona_host' => 'https://users.talis.com',
     'persona_oauth_route' => '/oauth/tokens',
     'userAgent' => 'my-app/2.0',
+    'cacheBackend' => $cacheBackend,
 ));
 
 // you can use it to get a user profile with the gupid
@@ -118,6 +119,7 @@ $personaClient = new Talis\Persona\Client\Login(array(
     'persona_host' => 'https://users.talis.com',
     'persona_oauth_route' => '/oauth/tokens',
     'userAgent' => 'my-app/2.0',
+    'cacheBackend' => $cacheBackend,
 ));
 
 // you can use it to login

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/persona-php-client",
   "description": "This is a php client library for Persona supporting generation, validation and caching of Oauth Tokens",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "keywords": ["persona", "php", "client library"],
   "homepage": "https://github.com/talis/persona-php-client",
   "type": "library",

--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -4,7 +4,6 @@ namespace Talis\Persona\Client;
 use Guzzle\Http\Exception\ClientErrorResponseException;
 use Monolog\Logger;
 use Guzzle\Http\Client;
-use Doctrine\Common\Cache\FilesystemCache;
 use Guzzle\Http\Exception\RequestException;
 use Guzzle\Cache\DoctrineCacheAdapter;
 use Guzzle\Plugin\Cache\CachePlugin;
@@ -101,13 +100,7 @@ abstract class Base
             ? $config['logger']
             : null;
 
-        $this->cacheBackend = isset($config['cacheBackend'])
-            ? $config['cacheBackend']
-            : new FilesystemCache(
-                sys_get_temp_dir() .
-                DIRECTORY_SEPARATOR .
-                'personaCache'
-            );
+        $this->cacheBackend = $config['cacheBackend'];
 
         $this->keyPrefix = isset($config['cacheKeyPrefix'])
             ? $config['cacheKeyPrefix']
@@ -160,6 +153,7 @@ abstract class Base
             'userAgent',
             'persona_host',
             'persona_oauth_route',
+            'cacheBackend'
         );
 
         $missingProperties = array();

--- a/test/integration/OAuthClientsTest.php
+++ b/test/integration/OAuthClientsTest.php
@@ -40,21 +40,24 @@ class OAuthClientsTest extends TestBase {
             array(
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $this->personaClientUser = new Users(
             array(
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $this->personaClientTokens = new Tokens(
             array(
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
@@ -128,6 +131,7 @@ class OAuthClientsTest extends TestBase {
                 'userAgent' => 'integrationtest',
                 'persona_host' => 'persona',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->getOAuthClient('123', '456');

--- a/test/integration/TokensTest.php
+++ b/test/integration/TokensTest.php
@@ -32,6 +32,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             ),
             null,
             $this->personaCache

--- a/test/integration/UsersTest.php
+++ b/test/integration/UsersTest.php
@@ -37,6 +37,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $this->personaClientTokens = new Tokens(
@@ -44,6 +45,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
@@ -116,6 +118,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'integrationtest',
                 'persona_host' => 'persona',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->getUserByGupid('123', '456');

--- a/test/unit/LoginTest.php
+++ b/test/unit/LoginTest.php
@@ -10,6 +10,8 @@ if (!defined('APPROOT'))
 
 require_once $appRoot . '/test/unit/TestBase.php';
 
+
+
 class LoginTest extends TestBase {
     // requireAuth tests
     function testRequireAuthNoProvider()
@@ -33,6 +35,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->requireAuth();
@@ -46,6 +49,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->requireAuth(array('test'), 'appid', 'appsecret');
@@ -70,6 +74,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->requireAuth('trapdoor');
@@ -83,6 +88,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->requireAuth('trapdoor', array('appid'), 'appsecret');
@@ -107,6 +113,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->requireAuth('trapdoor', 'appId');
@@ -120,6 +127,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->requireAuth('trapdoor', 'appid', array('appsecret'));
@@ -131,6 +139,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -151,6 +160,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->requireAuth('trapdoor', 'appid', 'appsecret', array('redirectUri'));
@@ -162,6 +172,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -181,6 +192,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -199,6 +211,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -224,6 +237,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->validateAuth();
@@ -237,6 +251,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_POST['persona:payload'] = 'YouShallNotPass';
@@ -250,6 +265,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginState'] = 'Tennessee';
@@ -264,6 +280,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginState'] = 'Tennessee';
@@ -278,6 +295,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginState'] = 'Tennessee';
@@ -299,6 +317,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginState'] = 'Tennessee';
@@ -328,6 +347,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginState'] = 'Tennessee';
@@ -377,6 +397,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -418,6 +439,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->exactly(2))
@@ -471,6 +493,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $this->assertFalse($personaClient->getPersistentId());
@@ -482,6 +505,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginSSO'] = array();
@@ -494,6 +518,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginSSO'] = array();
@@ -506,6 +531,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginProvider'] = 'trapdoor';
@@ -520,6 +546,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginProvider'] = 'trapdoor';
@@ -536,6 +563,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginProvider'] = 'trapdoor';
@@ -554,6 +582,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $this->assertFalse($personaClient->getRedirectUrl());
@@ -565,6 +594,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginSSO'] = array();
@@ -577,6 +607,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginSSO'] = array('redirect' => 'http://example.com/path/to/redirect');
@@ -591,6 +622,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $this->assertFalse($personaClient->getScopes());
@@ -602,6 +634,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginSSO'] = array();
@@ -615,6 +648,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginSSO'] = array('token' => array('scope' => array('919191')));
@@ -628,6 +662,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $this->assertEquals(array(), $personaClient->getProfile());
@@ -639,6 +674,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $_SESSION[Login::LOGIN_PREFIX.':loginSSO'] = array();
@@ -651,6 +687,7 @@ class LoginTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $profile = array('name' => '', 'email' => '');

--- a/test/unit/OAuthClientsTest.php
+++ b/test/unit/OAuthClientsTest.php
@@ -20,6 +20,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->getOAuthClient('', '');
@@ -31,6 +32,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->getOAuthClient('123', '');
@@ -43,6 +45,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -58,6 +61,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $expectedResponse = array(
@@ -90,6 +94,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient();
@@ -102,6 +107,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123');
@@ -114,6 +120,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123', array());
@@ -126,6 +133,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('', array(), '987');
@@ -138,6 +146,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient(array(), array(), '987');
@@ -150,6 +159,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123', array(), '987');
@@ -162,6 +172,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123', 'PROPERTIES', '987');
@@ -174,6 +185,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123', array('INVALID' => array()), '987');
@@ -186,6 +198,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123', array('scope' => array()), '987');
@@ -198,6 +211,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123', array('scope' => array('blah' => '')), '987');
@@ -210,6 +224,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123', array('scope' => array('blah' => '', '$add' => 'test')), '987');
@@ -222,6 +237,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123', array('scope' => array('blah' => '', '$remove' => 'remove-scope', '$add' => 'add-scope')), '987');
@@ -234,6 +250,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123', array('scope' => array('$add' => 'additional-scope')), '');
@@ -246,6 +263,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateOAuthClient('123',  array('scope' => array('$add' => 'additional-scope')), array(''));
@@ -258,6 +276,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -273,6 +292,7 @@ class OAuthClientsTest extends TestBase
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
 

--- a/test/unit/TestBase.php
+++ b/test/unit/TestBase.php
@@ -4,6 +4,8 @@ if (!defined('APPROOT'))
     define('APPROOT', dirname(dirname(__DIR__)));
 }
 
+use Doctrine\Common\Cache\FilesystemCache;
+
 /**
  * Retrieve environment variable, else return a default
  * @param string $name name of environment value
@@ -18,6 +20,15 @@ function envvalue($name, $default)
 
 abstract class TestBase extends PHPUnit_Framework_TestCase
 {
+    protected $cacheBackend = null;
+
+    public function __construct()
+    {
+        $this->cacheBackend = new FilesystemCache(
+            sys_get_temp_dir() . DIRECTORY_SEPARATOR .  'personaCache'
+        );
+    }
+
     protected function removeCacheFolder()
     {
         $dir = '/tmp/personaCache';

--- a/test/unit/TokensTest.php
+++ b/test/unit/TokensTest.php
@@ -38,7 +38,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => null,
-                'persona_oauth_route' => null
+                'persona_oauth_route' => null,
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
@@ -48,7 +49,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
@@ -61,7 +63,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -78,7 +81,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -92,7 +96,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -106,7 +111,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -125,7 +131,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -140,7 +147,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -159,7 +167,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -173,6 +182,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -186,6 +196,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -199,6 +210,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -212,6 +224,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -226,6 +239,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -240,6 +254,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -254,6 +269,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -268,6 +284,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -284,6 +301,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
 
@@ -299,7 +317,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
 
@@ -314,6 +333,7 @@ class TokensTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
 
@@ -346,6 +366,7 @@ class TokensTest extends TestBase {
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
                     'persona_oauth_route' => '/oauth/tokens',
+                    'cacheBackend' => $this->cacheBackend,
                 )
             )
         );
@@ -388,6 +409,7 @@ class TokensTest extends TestBase {
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
                     'persona_oauth_route' => '/oauth/tokens',
+                    'cacheBackend' => $this->cacheBackend,
                 )
             )
         );
@@ -430,6 +452,7 @@ class TokensTest extends TestBase {
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
                     'persona_oauth_route' => '/oauth/tokens',
+                    'cacheBackend' => $this->cacheBackend,
                 )
             )
         );
@@ -471,6 +494,7 @@ class TokensTest extends TestBase {
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
                     'persona_oauth_route' => '/oauth/tokens',
+                    'cacheBackend' => $this->cacheBackend,
                 )
             )
         );
@@ -512,6 +536,7 @@ class TokensTest extends TestBase {
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
                     'persona_oauth_route' => '/oauth/tokens',
+                    'cacheBackend' => $this->cacheBackend,
                 )
             )
         );
@@ -566,6 +591,7 @@ class TokensTest extends TestBase {
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
                     'persona_oauth_route' => '/oauth/tokens',
+                    'cacheBackend' => $this->cacheBackend,
                 )
             )
         );
@@ -623,23 +649,25 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest//.1',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
 
     public function testUserAgentFailsWithDoubleSpace()
     {
-        $this->setExpectedException(		
-            'InvalidArgumentException',		
-            'user agent format is not valid'		
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'user agent format is not valid'
         );
 
         $personaClient = new Tokens(
             array(
                 'userAgent' => 'unittest//.1  (blah)',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
@@ -651,7 +679,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
@@ -662,7 +691,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest/1.09',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
@@ -673,7 +703,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest/1723-9095ba4',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
@@ -684,7 +715,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest/3.02 (commenting; here)',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
@@ -695,7 +727,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest/13f3-00934fa4 (commenting; with; hash)',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }
@@ -706,7 +739,8 @@ class TokensTest extends TestBase {
             array(
                 'userAgent' => 'unittest (comment; with; basic; name)',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens'
+                'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
     }

--- a/test/unit/UsersTest.php
+++ b/test/unit/UsersTest.php
@@ -18,6 +18,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->getUserByGupid('', '');
@@ -29,6 +30,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->getUserByGupid('123', '');
@@ -41,6 +43,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -56,6 +59,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $expectedResponse = array(
@@ -95,6 +99,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->getUserByGuids('', '');
@@ -106,6 +111,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->getUserByGuids(array('123'), '');
@@ -117,6 +123,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->getUserByGuids(array('123'), '456');
@@ -129,6 +136,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -144,6 +152,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $expectedResponse = array(array(
@@ -186,6 +195,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->createUser();
@@ -198,6 +208,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->createUser('gupid');
@@ -210,6 +221,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->createUser('gupid', 'profile');
@@ -223,6 +235,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->createUser('', 'profile', 'token');
@@ -235,6 +248,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->createUser(array('gupid'), 'profile', 'token');
@@ -247,6 +261,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $expectedResponse = array('gupid' => '123');
@@ -263,6 +278,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->createUser('gupid', 'profile', 'token');
@@ -276,6 +292,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->createUser('gupid', array('email' => ''), '');
@@ -288,6 +305,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->createUser('gupid', array('email' => ''), array(''));
@@ -300,6 +318,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -314,6 +333,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $expectedResponse = array('gupid' => '123', 'profile' => array());
@@ -332,6 +352,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateUser();
@@ -344,6 +365,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateUser('123');
@@ -356,6 +378,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateUser('123', array());
@@ -368,6 +391,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateUser('', array(), '987');
@@ -380,6 +404,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateUser(array(), array(), '987');
@@ -392,6 +417,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateUser('123', array(), '987');
@@ -404,6 +430,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateUser('123', 'PROFILE', '987');
@@ -416,6 +443,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateUser('123', array('email' => 'PROFILE'), '');
@@ -428,6 +456,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         );
         $personaClient->updateUser('123', array('email' => 'PROFILE'), array(''));
@@ -440,6 +469,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $mockClient->expects($this->once())
@@ -454,6 +484,7 @@ class UsersTest extends TestBase {
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
                 'persona_oauth_route' => '/oauth/tokens',
+                'cacheBackend' => $this->cacheBackend,
             )
         ));
         $expectedResponse = array('gupid' => '123', 'profile' => array());


### PR DESCRIPTION
The FileSystemCache has been found to generate 32 folders per cache key & not remove old items. This causes the inodes to become depleted.

Removing the use of FileSystemCache as a default storage mechanism & forcing the user of the library to supply a cache storage.

fixes https://github.com/talis/platform/issues/356