### PR TITLE
90% Dependency update and server side login fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     "monolog/monolog": ">=1.13.1",
     "domnikl/statsd": ">=1.0.2",
     "psr/log" : ">=1.0.0",
-    "guzzlehttp/guzzle" : "^6.0",
     "firebase/php-jwt": "^3.0",
-    "doctrine/common": "^2.5"
+    "doctrine/common": "^2.5",
+    "guzzle/guzzle": "^3.8"
   },
   "require-dev":{
     "phpunit/phpunit": "4.2.0"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/persona-php-client",
   "description": "This is a php client library for Persona supporting generation, validation and caching of Oauth Tokens",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "keywords": ["persona", "php", "client library"],
   "homepage": "https://github.com/talis/persona-php-client",
   "type": "library",
@@ -18,7 +18,7 @@
     "monolog/monolog": ">=1.13.1",
     "domnikl/statsd": ">=1.0.2",
     "psr/log" : ">=1.0.0",
-    "guzzlehttp/guzzle" : "^3.8",
+    "guzzlehttp/guzzle" : "^6.0",
     "firebase/php-jwt": "^3.0",
     "doctrine/common": "^2.5"
   },

--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -67,7 +67,7 @@ abstract class Base
      *      persona_oauth_route: (string) the token api route to query ( e.g: '/oauth/tokens')
      *      userAgent: Consuming application user agent string @since 2.0.0
      *            examples: rl/1723-9095ba4, rl/5.2, rl, rl/5, rl/5.2 (php/5.3; linux/2.5)
-     *      cacheBackend: (Doctrine\Common\Cache\CacheProvider) optional cache storage (defaults to Filesystem)
+     *      cacheBackend: (Doctrine\Common\Cache\CacheProvider) cache storage
      *      cacheKeyPrefix: (string) optional prefix to append to the cache keys
      *      cacheDefaultTTL: (integer) optional cache TTL value
      * @throws \InvalidArgumentException if any of the required config parameters are missing

--- a/test/unit/LoginTest.php
+++ b/test/unit/LoginTest.php
@@ -229,7 +229,7 @@ class LoginTest extends TestBase {
     }
 
     // validateAuth tests
-    function testValidateAuthPayloadDoesNotContainSignature()
+    function testValidateAuthThrowsExceptionWhenPayloadDoesNotContainSignature()
     {
         $this->setExpectedException('Exception', 'Signature not set');
         $personaClient = new Login(
@@ -243,7 +243,7 @@ class LoginTest extends TestBase {
         $personaClient->validateAuth();
     }
 
-    function testValidateAuthNoPayload()
+    function testValidateAuthThrowsExceptionWhenPayloadDoesNotExist()
     {
         $this->setExpectedException('Exception', 'Payload not set');
         $personaClient = new Login(
@@ -258,7 +258,7 @@ class LoginTest extends TestBase {
         $personaClient->validateAuth();
     }
 
-    function testValidateAuthPayloadIsAString()
+    function testValidateAuthThrowsExceptionWhenPayloadIsAString()
     {
         $this->setExpectedException('Exception', 'Payload not json');
         $personaClient = new Login(
@@ -274,7 +274,7 @@ class LoginTest extends TestBase {
         $personaClient->validateAuth();
     }
 
-    function testValidateAuthPayloadDoesNotContainState()
+    function testValidateAuthThrowsExceptionWhenPayloadIsMissingState()
     {
         $this->setExpectedException('Exception', 'Login state does not match');
         $personaClient = new Login(


### PR DESCRIPTION
This PR:
* changes where we read the payload signature from - instead of reading it from a field within the payload we now read it from `$_POST['persona:signature']`
* changes the namespace of guzzle from `guzzlehttp/guzzle` to `guzzle/guzzle` to avoid conflicts with projects (depot in [this case](talis/platform#49)) that use newer versions of guzzle which live in the `guzzlehttp` namespace (for more context see talis/platform#532 raised to upgrade guzzle to the latest version, after chatting to Chris decided to raise a separate story for this rather than doing it all within PLAT-49)

TODO:
* [x] Fix unit tests broken by changing where the signature is read from