### PR TITLE
90% - PLAT-897 - Remote verification append su

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ services:
 sudo: false
 language: php
 php:
-- 7.1
 - 7.0
 - 5.6
 - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
 - 5.6
 - 5.5
 - 5.4
-- 5.3
 install:
 - composer install
 script: ant test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ services:
 sudo: false
 language: php
 php:
+- 7.1
+- 7.0
 - 5.6
 - 5.5
 - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ services:
 sudo: false
 language: php
 php:
-- 7.0
 - 5.6
 - 5.5
 - 5.4

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/persona-php-client",
   "description": "This is a php client library for Persona supporting generation, validation and caching of Oauth Tokens",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "keywords": ["persona", "php", "client library"],
   "homepage": "https://github.com/talis/persona-php-client",
   "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/persona-php-client",
   "description": "This is a php client library for Persona supporting generation, validation and caching of Oauth Tokens",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "keywords": ["persona", "php", "client library"],
   "homepage": "https://github.com/talis/persona-php-client",
   "type": "library",

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -132,7 +132,7 @@ class Tokens extends Base
             $url .= '?scope=';
             $url .= $scope !== 'su'
                 ? 'su,' . $scope
-                : $scoppe;
+                : $scope;
         }
 
         $this->getStatsD()->startTiming('validateToken.rest.get');

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -129,7 +129,10 @@ class Tokens extends Base
         $url = $this->config['persona_host'] . $this->config['persona_oauth_route'] . '/' . $token;
 
         if (empty($scope) === false) {
-            $url .= '?scope=su,' . $scope;
+            $url .= '?scope=';
+            $url .= $scope !== 'su'
+                ? 'su,' . $scope
+                : $scoppe;
         }
 
         $this->getStatsD()->startTiming('validateToken.rest.get');

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -129,7 +129,7 @@ class Tokens extends Base
         $url = $this->config['persona_host'] . $this->config['persona_oauth_route'] . '/' . $token;
 
         if (empty($scope) === false) {
-            $url .= '?scope=' . $scope;
+            $url .= '?scope=su,' . $scope;
         }
 
         $this->getStatsD()->startTiming('validateToken.rest.get');

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -66,7 +66,6 @@ class Tokens extends Base
     protected function validateTokenUsingJWT($token, $scope, $cacheTTL = 300)
     {
         $cert = $this->retrieveJWTCertificate($cacheTTL);
-
         try {
             $decoded = (array) JWT::decode($token, $cert, array('RS256'));
         } catch (\DomainException $exception) {


### PR DESCRIPTION
Verify against `su` scope when using remote validation.
fixes https://github.com/talis/platform/issues/898