### PR TITLE
90% - PLAT-956 - allow multiple scopes when validating

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/persona-php-client",
   "description": "This is a php client library for Persona supporting generation, validation and caching of Oauth Tokens",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "keywords": [
     "persona",
     "php",

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -125,7 +125,7 @@ class Tokens extends Base
             $suKey = array_search('su', $scopes, true);
 
             if ($suKey === false) {
-                array_push($scopes, 'su');
+                array_unshift($scopes, 'su');
             }
 
             $url .= '?scope=' . join(',', $scopes);

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -122,7 +122,9 @@ class Tokens extends Base
         $url = $this->getPersonaHost() . $this->config['persona_oauth_route'] . '/' . $token;
 
         if (empty($scopes) === false) {
-            if (empty(array_search('su', $scopes, true))) {
+            $suKey = array_search('su', $scopes, true);
+
+            if ($suKey === false) {
                 array_push($scopes, 'su');
             }
 

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -125,6 +125,11 @@ class Tokens extends Base
             $suKey = array_search('su', $scopes, true);
 
             if ($suKey === false) {
+                // When validating remotely persona will ensure at least one of
+                // the scopes validates against the token. As `su` should
+                // override all other scopes, it should always be appended to
+                // the `scope` parameter. If it isn't appended it would mean
+                // that the scopes must explicity exist.
                 array_unshift($scopes, 'su');
             }
 

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -19,7 +19,7 @@ class Tokens extends Base
      *
      * @param array $params a set of optional parameters you can pass to this method <pre>
      *      access_token: (string) a token to validate explicitly, if you do not specify one the method tries to find one,
-     *      scope: (string) specify this if you wish to validate a scoped token
+     *      scope: (string|array) specify this if you wish to validate a scoped token
      * @return bool|string will return false if could not validate the token, else true
      * @throws \Exception if you do not supply a token AND it cannot extract one from $_SERVER, $_GET, $_POST
      * @throws DomainException invalid public key
@@ -33,10 +33,8 @@ class Tokens extends Base
             $token = $this->getTokenFromRequest();
         }
 
-        $scope = null;
-        if (isset($params['scope'])) {
-            $scope = $params['scope'];
-        }
+        $scope = isset($params['scope']) ? $params['scope'] : null;
+        $scope = is_null($scope) || is_array($scope) ? $scope : [$scope];
 
         try {
             return $this->validateTokenUsingJWT($token, $scope);
@@ -49,7 +47,7 @@ class Tokens extends Base
      * Validate the given token by using JWT
      * @param string $token a token to validate explicitly, if you do not
      *      specify one the method tries to find one
-     * @param string $scope specify this if you wish to validate a scoped token
+     * @param array|null $scopes specify this if you wish to validate a scoped token
      * @param int $cacheTTL time to live value in seconds for the certificate to stay within cache
      * @return bool|string will return false if could not validate the token, else true
      * @throws ScopesNotDefinedException if the JWT token doesn't include the user's scopes
@@ -57,7 +55,7 @@ class Tokens extends Base
      * @throws DomainException invalid public key
      * @throw InvalidArgumentException invalid public key format
      */
-    protected function validateTokenUsingJWT($token, $scope, $cacheTTL = 300)
+    protected function validateTokenUsingJWT($token, $scopes, $cacheTTL = 300)
     {
         $cert = $this->retrieveJWTCertificate($cacheTTL);
         try {
@@ -74,7 +72,7 @@ class Tokens extends Base
             return false;
         }
 
-        if ($scope === null) {
+        if ($scopes === null) {
             return true;
         } else {
             if (isset($decoded['scopeCount'])) {
@@ -85,7 +83,7 @@ class Tokens extends Base
         }
 
         $isSu = in_array('su', $decoded['scopes'], true);
-        $hasScope = in_array($scope, $decoded['scopes'], true);
+        $hasScope = count(array_intersect($scopes, $decoded['scopes'])) > 0;
         return $isSu || $hasScope ? true : false;
     }
 
@@ -113,21 +111,22 @@ class Tokens extends Base
      * Validate the given token by using Persona
      * @param array $params a set of optional parameters you can pass to this method <pre>
      *      access_token: (string) a token to validate explicitly, if you do not specify one the method tries to find one,
-     *      scope: (string) specify this if you wish to validate a scoped token
+     *      scopes: (array) specify this if you wish to validate a scoped token
      * @return bool|string will return false if could not validate the token, else true
      * $throws \Exception if you do not supply a token AND it cannot extract one from $_SERVER, $_GET, $_POST
      */
-    protected function validateTokenUsingPersona($token, $scope)
+    protected function validateTokenUsingPersona($token, $scopes)
     {
         // verify against persona
         $this->getStatsD()->increment('validateToken.cache.miss');
         $url = $this->getPersonaHost() . $this->config['persona_oauth_route'] . '/' . $token;
 
-        if (empty($scope) === false) {
-            $url .= '?scope=';
-            $url .= $scope !== 'su'
-                ? 'su,' . $scope
-                : $scope;
+        if (empty($scopes) === false) {
+            if (empty(array_search('su', $scopes, true))) {
+                array_push($scopes, 'su');
+            }
+
+            $url .= '?scope=' . join(',', $scopes);
         }
 
         $this->getStatsD()->startTiming('validateToken.rest.get');

--- a/test/unit/TokensTest.php
+++ b/test/unit/TokensTest.php
@@ -948,13 +948,6 @@ class TokensTest extends TestBase
         ]));
     }
 
-
-
-
-
-
-
-
     public function testLocalValidationCallsMultipleScopes()
     {
         $client = new Tokens([
@@ -988,7 +981,7 @@ class TokensTest extends TestBase
         ]));
     }
 
-    public function testRemoteValidationCallsMultipleScopesWithSu()
+    public function testLocalValidationCallsMultipleScopesWithSu()
     {
         $client = new Tokens([
             'userAgent' => 'unittest',

--- a/test/unit/TokensTest.php
+++ b/test/unit/TokensTest.php
@@ -967,26 +967,20 @@ class TokensTest extends TestBase
             ->method('retrieveJWTCertificate')
             ->will($this->returnValue($this->_publicKey));
 
-        $accessToken = json_encode(
+        $jwt = JWT::encode(
             [
-                'access_token' => JWT::encode(
-                    [
-                        'jwtid' => time(),
-                        'exp' => time() + 100,
-                        'nbf' => time() - 1,
-                        'audience' => 'standard_user',
-                        'scopes' => ['invalid1', 'scope2'],
-                    ],
-                    $this->_privateKey,
-                    'RS256'
-                ),
-                'expires_in' => 100,
-                'token_type' => 'bearer',
-            ]
+                'jwtid' => time(),
+                'exp' => time() + 100,
+                'nbf' => time() - 1,
+                'audience' => 'standard_user',
+                'scopes' => ['invalid1', 'scope2'],
+            ],
+            $this->_privateKey,
+            'RS256'
         );
 
         $this->assertTrue($mockClient->validateToken([
-            'access_token' => $accessToken,
+            'access_token' => $jwt,
             'scope' => ['scope1', 'scope2'],
         ]));
     }
@@ -1010,26 +1004,20 @@ class TokensTest extends TestBase
             ->method('retrieveJWTCertificate')
             ->will($this->returnValue($this->_publicKey));
 
-        $accessToken = json_encode(
+        $jwt = JWT::encode(
             [
-                'access_token' => JWT::encode(
-                    [
-                        'jwtid' => time(),
-                        'exp' => time() + 100,
-                        'nbf' => time() - 1,
-                        'audience' => 'standard_user',
-                        'scopes' => ['invalid1', 'scope2'],
-                    ],
-                    $this->_privateKey,
-                    'RS256'
-                ),
-                'expires_in' => 100,
-                'token_type' => 'bearer',
-            ]
+                'jwtid' => time(),
+                'exp' => time() + 100,
+                'nbf' => time() - 1,
+                'audience' => 'standard_user',
+                'scopes' => ['invalid1', 'scope2'],
+            ],
+            $this->_privateKey,
+            'RS256'
         );
 
         $this->assertTrue($mockClient->validateToken([
-            'access_token' => $accessToken,
+            'access_token' => $jwt,
             'scope' => ['scope1', 'scope2', 'su'],
         ]));
     }

--- a/test/unit/TokensTest.php
+++ b/test/unit/TokensTest.php
@@ -1028,7 +1028,7 @@ class TokensTest extends TestBase
             ]
         );
 
-        $this->assertTrue($client->validateToken([
+        $this->assertTrue($mockClient->validateToken([
             'access_token' => $accessToken,
             'scope' => ['scope1', 'scope2', 'su'],
         ]));

--- a/test/unit/TokensTest.php
+++ b/test/unit/TokensTest.php
@@ -950,12 +950,22 @@ class TokensTest extends TestBase
 
     public function testLocalValidationCallsMultipleScopes()
     {
-        $client = new Tokens([
-            'userAgent' => 'unittest',
-            'persona_host' => 'localhost',
-            'persona_oauth_route' => '/oauth/tokens',
-            'cacheBackend' => $this->cacheBackend,
-        ]);
+        $mockClient = $this->getMock(
+            'Talis\Persona\Client\Tokens',
+            [ 'retrieveJWTCertificate' ],
+            [
+                [
+                    'userAgent' => 'unittest',
+                    'persona_host' => 'localhost',
+                    'persona_oauth_route' => '/oauth/tokens',
+                    'cacheBackend' => $this->cacheBackend,
+                ]
+            ]
+        );
+
+        $mockClient->expects($this->once())
+            ->method('retrieveJWTCertificate')
+            ->will($this->returnValue($this->_publicKey));
 
         $accessToken = json_encode(
             [
@@ -975,7 +985,7 @@ class TokensTest extends TestBase
             ]
         );
 
-        $this->assertTrue($client->validateToken([
+        $this->assertTrue($mockClient->validateToken([
             'access_token' => $accessToken,
             'scope' => ['scope1', 'scope2'],
         ]));
@@ -983,12 +993,22 @@ class TokensTest extends TestBase
 
     public function testLocalValidationCallsMultipleScopesWithSu()
     {
-        $client = new Tokens([
-            'userAgent' => 'unittest',
-            'persona_host' => 'localhost',
-            'persona_oauth_route' => '/oauth/tokens',
-            'cacheBackend' => $this->cacheBackend,
-        ]);
+        $mockClient = $this->getMock(
+            'Talis\Persona\Client\Tokens',
+            [ 'retrieveJWTCertificate' ],
+            [
+                [
+                    'userAgent' => 'unittest',
+                    'persona_host' => 'localhost',
+                    'persona_oauth_route' => '/oauth/tokens',
+                    'cacheBackend' => $this->cacheBackend,
+                ]
+            ]
+        );
+
+        $mockClient->expects($this->once())
+            ->method('retrieveJWTCertificate')
+            ->will($this->returnValue($this->_publicKey));
 
         $accessToken = json_encode(
             [


### PR DESCRIPTION
Allow the user to validate a token against multiple scopes. If any of the scopes are valid against the token, the validation is a success.