### PR TITLE
90% - PLAT-1417 - Remove config of persona_oauth_route

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ $cacheDriver->setRedis($redis);
 
 $personaClient = new Talis\Persona\Client\Login(array(
     'persona_host' => 'https://users.talis.com',
-    'persona_oauth_route' => '/oauth/tokens/',
     'userAgent' => 'my-app/2.0',
     'cacheBackend' =>  $cacheDriver,
 ));
@@ -62,7 +61,6 @@ Where applicable, each API call can override the global TTL by passing in a TTL 
 $cacheTTL = 300;
 $users = new Talis\Persona\Client\Users(array(
     'persona_host' => 'https://users.talis.com',
-    'persona_oauth_route' => '/oauth/tokens/',
     'userAgent' => 'my-app/2.0',
 ));
 $users->getUserByGupid($gupid, $token, $cacheTTL);
@@ -76,7 +74,6 @@ of the profile should use a 0 TTL to remove any cache.
 // create an instance of the client
 $personaClient = new Talis\Persona\Client\Tokens(array(
     'persona_host' => 'https://users.talis.com',
-    'persona_oauth_route' => '/oauth/tokens',
     'userAgent' => 'my-app/2.0',
     'cacheBackend' => $cacheBackend,
 ));
@@ -103,7 +100,6 @@ $tokenDetails = $personaClient->obtainNewToken(
 // create an instance of the client
 $personaClient = new Talis\Persona\Client\Users(array(
     'persona_host' => 'https://users.talis.com',
-    'persona_oauth_route' => '/oauth/tokens',
     'userAgent' => 'my-app/2.0',
     'cacheBackend' => $cacheBackend,
 ));
@@ -117,7 +113,6 @@ $profile = $personaClient->getUserByGupid('google:123', 'some token');
 // create an instance of the client
 $personaClient = new Talis\Persona\Client\Login(array(
     'persona_host' => 'https://users.talis.com',
-    'persona_oauth_route' => '/oauth/tokens',
     'userAgent' => 'my-app/2.0',
     'cacheBackend' => $cacheBackend,
 ));

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/persona-php-client",
   "description": "This is a php client library for Persona supporting generation, validation and caching of Oauth Tokens",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "keywords": [
     "persona",
     "php",

--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -64,7 +64,6 @@ abstract class Base
      *
      * @param array $config An array of options with the following keys: <pre>
      *      persona_host: (string) the persona host you'll be making requests to (e.g. 'http://localhost')
-     *      persona_oauth_route: (string) the token api route to query ( e.g: '/oauth/tokens')
      *      userAgent: Consuming application user agent string @since 2.0.0
      *            examples: rl/1723-9095ba4, rl/5.2, rl, rl/5, rl/5.2 (php/5.3; linux/2.5)
      *      cacheBackend: (Doctrine\Common\Cache\CacheProvider) cache storage
@@ -77,6 +76,7 @@ abstract class Base
     {
         $this->checkConfig($config);
         $this->config = $config;
+        $this->config['persona_oauth_route'] = '/oauth/tokens';
 
         $userAgentPattern = '' .
             '/^[a-z0-9\-\._]+' .             // name of application
@@ -154,7 +154,6 @@ abstract class Base
         $requiredProperties = [
             'userAgent',
             'persona_host',
-            'persona_oauth_route',
             'cacheBackend'
         ];
 

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -339,7 +339,6 @@ class Tokens extends Base
 
         $requiredProperties = [
             'persona_host',
-            'persona_oauth_route',
         ];
 
         $missingProperties = [];

--- a/test/integration/OAuthClientsTest.php
+++ b/test/integration/OAuthClientsTest.php
@@ -41,7 +41,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -49,7 +48,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -57,7 +55,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -140,7 +137,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'integrationtest',
                 'persona_host' => 'persona',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );

--- a/test/integration/TokensTest.php
+++ b/test/integration/TokensTest.php
@@ -32,7 +32,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->personaCache,
             ]
         );

--- a/test/integration/UsersTest.php
+++ b/test/integration/UsersTest.php
@@ -36,7 +36,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -44,7 +43,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'integrationtest',
                 'persona_host' => $personaConf['host'],
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -150,7 +148,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'integrationtest',
                 'persona_host' => 'persona',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );

--- a/test/unit/LoginTest.php
+++ b/test/unit/LoginTest.php
@@ -526,6 +526,19 @@ class LoginTest extends TestBase
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
+        $_SESSION[Login::LOGIN_PREFIX . ':loginSSO'] = [];
+        $this->assertFalse($personaClient->getPersistentId());
+    }
+
+    function testGetPersistentIdEmptyGupids()
+    {
+        $personaClient = new Login(
+            [
+                'userAgent' => 'unittest',
+                'persona_host' => 'localhost',
+                'cacheBackend' => $this->cacheBackend,
+            ]
+        );
         $_SESSION[Login::LOGIN_PREFIX . ':loginProvider'] = 'trapdoor';
         $_SESSION[Login::LOGIN_PREFIX . ':loginSSO'] = ['gupid' => []];
 
@@ -679,6 +692,20 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
+                'cacheBackend' => $this->cacheBackend,
+            ]
+        );
+        $profile = ['name' => '', 'email' => ''];
+        $_SESSION[Login::LOGIN_PREFIX . ':loginSSO'] = ['profile' => $profile];
+        $this->assertEquals($profile, $personaClient->getProfile());
+    }
+
+    function testRequireAuthRequireProfile()
+    {
+        $arguments = [
+            [
+                'userAgent' => 'unittest',
+                'persona_host' => 'http://localhost',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ];

--- a/test/unit/LoginTest.php
+++ b/test/unit/LoginTest.php
@@ -33,7 +33,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -48,7 +47,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -74,7 +72,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -89,7 +86,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -115,7 +111,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -130,7 +125,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -143,7 +137,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -165,7 +158,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -178,7 +170,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -199,7 +190,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -219,7 +209,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -245,7 +234,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -259,7 +247,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -274,7 +261,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -290,7 +276,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -307,7 +292,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -331,7 +315,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -364,7 +347,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -418,7 +400,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -462,7 +443,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -518,7 +498,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -531,7 +510,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -545,21 +523,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
-                'cacheBackend' => $this->cacheBackend,
-            ]
-        );
-        $_SESSION[Login::LOGIN_PREFIX . ':loginSSO'] = [];
-        $this->assertFalse($personaClient->getPersistentId());
-    }
-
-    function testGetPersistentIdEmptyGupids()
-    {
-        $personaClient = new Login(
-            [
-                'userAgent' => 'unittest',
-                'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -575,7 +538,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -595,7 +557,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -616,7 +577,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -629,7 +589,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -643,7 +602,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -658,7 +616,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -671,7 +628,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -685,7 +641,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -699,7 +654,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -712,7 +666,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -726,22 +679,6 @@ class LoginTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
-                'cacheBackend' => $this->cacheBackend,
-            ]
-        );
-        $profile = ['name' => '', 'email' => ''];
-        $_SESSION[Login::LOGIN_PREFIX . ':loginSSO'] = ['profile' => $profile];
-        $this->assertEquals($profile, $personaClient->getProfile());
-    }
-
-    function testRequireAuthRequireProfile()
-    {
-        $arguments = [
-            [
-                'userAgent' => 'unittest',
-                'persona_host' => 'http://localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ];

--- a/test/unit/OAuthClientsTest.php
+++ b/test/unit/OAuthClientsTest.php
@@ -19,7 +19,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -33,7 +32,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -47,7 +45,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -64,7 +61,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -97,7 +93,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -111,7 +106,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -125,7 +119,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -139,7 +132,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -153,7 +145,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -167,7 +158,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -181,7 +171,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -195,7 +184,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -209,7 +197,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -223,7 +210,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -237,7 +223,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -251,7 +236,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -266,7 +250,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -280,7 +263,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -294,7 +276,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -311,7 +292,6 @@ class OAuthClientsTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);

--- a/test/unit/TokensTest.php
+++ b/test/unit/TokensTest.php
@@ -35,13 +35,12 @@ class TokensTest extends TestBase
     function testMissingRequiredConfigParamsThrowsException()
     {
         $this->setExpectedException('InvalidArgumentException',
-            'Config provided does not contain values for: persona_host,persona_oauth_route'
+            'Config provided does not contain values for: persona_host'
         );
         $personaClient = new Tokens(
             [
                 'userAgent' => 'unittest',
                 'persona_host' => null,
-                'persona_oauth_route' => null,
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -53,7 +52,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -68,7 +66,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -87,7 +84,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -103,7 +99,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -119,7 +114,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -140,7 +134,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -157,7 +150,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -178,7 +170,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -194,7 +185,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -210,7 +200,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -226,7 +215,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -243,7 +231,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -259,7 +246,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -275,7 +261,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -292,7 +277,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -309,7 +293,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -328,7 +311,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -347,7 +329,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -367,7 +348,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -400,7 +380,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -443,7 +422,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -486,7 +464,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -528,7 +505,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -570,7 +546,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -625,7 +600,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -687,7 +661,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -741,7 +714,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -795,7 +767,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -849,7 +820,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -903,7 +873,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -957,7 +926,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -994,7 +962,6 @@ class TokensTest extends TestBase
                 [
                     'userAgent' => 'unittest',
                     'persona_host' => 'localhost',
-                    'persona_oauth_route' => '/oauth/tokens',
                     'cacheBackend' => $this->cacheBackend,
                 ]
             ]
@@ -1028,7 +995,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest//.1',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -1045,7 +1011,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest//.1  (blah)',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -1058,7 +1023,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -1070,7 +1034,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest/1.09',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -1082,7 +1045,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest/1723-9095ba4',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -1094,7 +1056,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest/3.02 (commenting; here)',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -1106,7 +1067,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest/13f3-00934fa4 (commenting; with; hash)',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -1118,7 +1078,6 @@ class TokensTest extends TestBase
             [
                 'userAgent' => 'unittest (comment; with; basic; name)',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );

--- a/test/unit/UsersTest.php
+++ b/test/unit/UsersTest.php
@@ -18,7 +18,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -32,7 +31,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -46,7 +44,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -63,7 +60,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -97,7 +93,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -111,7 +106,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -125,7 +119,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -142,7 +135,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -180,7 +172,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -194,7 +185,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -208,7 +198,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -222,7 +211,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -236,7 +224,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -249,7 +236,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -267,7 +253,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -281,7 +266,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -295,7 +279,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -309,7 +292,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -325,7 +307,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -344,7 +325,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -358,7 +338,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -372,7 +351,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -386,7 +364,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -400,7 +377,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -414,7 +390,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -428,7 +403,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -442,7 +416,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -456,7 +429,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -470,7 +442,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -486,7 +457,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -505,7 +475,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -519,7 +488,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -533,7 +501,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -547,7 +514,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -561,7 +527,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -575,7 +540,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -589,7 +553,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -603,7 +566,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -619,7 +581,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -638,7 +599,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -652,7 +612,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -666,7 +625,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -680,7 +638,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -694,7 +651,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -708,7 +664,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -722,7 +677,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
@@ -736,7 +690,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);
@@ -752,7 +705,6 @@ class UsersTest extends TestBase
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
-                'persona_oauth_route' => '/oauth/tokens',
                 'cacheBackend' => $this->cacheBackend,
             ]
         ]);


### PR DESCRIPTION
> Version 4 of the persona node client forced all the routes to use the version 3 API routes in Persona. As part of this change, the HEAD token request still uses config.persona_oauth_route but prefixed with the API version. Any consumers of the client who set the config.persona_oauth_route add the version to this and so you end up with /3/3/oauth/tokens which causes a 404.

fixes https://github.com/talis/platform/issues/1417